### PR TITLE
Tweak stacking context to show full iphone frame

### DIFF
--- a/01-tinder-swipe/index.html
+++ b/01-tinder-swipe/index.html
@@ -1,7 +1,8 @@
 <title>100 proyectos JS · 01 - Tinder Swipe</title>
-
+<div class="shadow">
 <main>
   <section>
+    <div class="white-bkg"></div>
     <header>
       <img src="./tinder-logo.webp" alt="Tinder Logo" />
     </header>
@@ -36,7 +37,7 @@
     </footer>
   </section>
 </main>
-
+</div>
 <style>
   *,
   *::before,
@@ -55,18 +56,25 @@
     user-select: none;
     background: #e5e5e5;
   }
-
+  .white-bkg {
+    position: absolute;
+    background: #f6f6f6;
+    inset: 0;
+    z-index: -10;
+  }
+  .shadow{
+    filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.3));
+  }
   main {
     background: url('./iphone.webp') no-repeat;
     background-size: contain;
     width: 320px;
     height: 640px;
     display: flex;
-    filter: drop-shadow(0 0 10px rgba(0, 0, 0, 0.3));
+    position: relative;
   }
 
   section {
-    background: #f6f6f6;
     width: 100%;
     border-radius: 32px;
     display: flex;
@@ -80,7 +88,8 @@
 
   header {
     display: flex;
-    justify-content: center;
+    justify-content: start;
+    padding-left: 1rem;
 
     & img {
       width: 24px;


### PR DESCRIPTION
# Motivación
Este commit ajusta los z-index y más cosas para que se vea el marco del iPhone.

# Disclaimer
Esta modificación es un poco tricky y lo he hecho más como ejercicio personal.

# Implementación

<img src="https://github.com/midudev/javascript-100-proyectos/assets/117351089/2c64fd1b-81c8-4cb8-8124-eede9c33597f" width="300"/>



Hacer que la imagen (background del `main`) se vea por encima de los hijos tiene varios _gotchas_:
El `filter: drop-shadow` crea un nuevo stacking context. Nosotros necesitamos que el `main` y el `section` hijo estén en el mismo contexto, para poder ajustar quien se ve encima.
Es por ello que saqué el `drop-shadow` a un elemento externo (`.shadow`)

La única manera de conseguir que un child esté por debajo del parent es usar un [`z-index `negativo](https://stackoverflow.com/questions/54897916/why-cant-an-element-with-a-z-index-value-cover-its-child)

Poner un z-index negativo a todo el section hace que el _drag-n-drop_ se rompa, porque el elemento que se inicia el _drag-n-drop_ sería el main y no la `img` del `article`. La función `element.Closest` busca en el árbol hacia arriba (_parent_) y en este caso entonces habría que cambiar la lógica a buscar hacia abajo. Es por todo esto que extraje a otro elemento el fondo del teléfono (`.white-bkg`). Y de esta manera se mantiene la lógica intacta.

Por último, ajusté la posición del logo.

# Conclusión
Creo que la mejor forma de resolver que se vea el marco del iPhone, es simplemente rellenar la imagen transparente con el color deseado `#f6f6f6`, dado que todos los demás elementos están por encima.


