### PR TITLE
fixing the size

### DIFF
--- a/web/src/components/Projects.astro
+++ b/web/src/components/Projects.astro
@@ -124,13 +124,13 @@ import { PROJECTS } from "../consts"
     })
   }
   <article
-    class="min-h-60 relative items-center text-black rounded-lg bg-purple-50"
+    class="min-h-60 flex justify-center relative items-center text-black rounded-lg bg-purple-50"
   >
     <a
       href="https://twitch.tv/midudev"
       target="_blank"
       rel="noopener noreferrer"
-      class="group hover:scale-110 transition flex justify-center flex-col h-full items-center font-semibold text-purple-700 text-center text-xl"
+      class="group hover:scale-110 transition flex justify-center flex-col items-center font-semibold text-purple-700 text-center text-xl"
     >
       <svg
         class="w-16 h-16 mb-2"


### PR DESCRIPTION
### Motivación
Este commit ajusta el tamaño y el hover de la etiqueta a del Próximamente en Twitch.

https://github.com/midudev/javascript-100-proyectos/assets/57204144/e2d6139a-47bd-4692-a095-8ec1e964a03e

en el video se puede ver el tamaño de la etiqueta y donde se empieza hacer el hover.

### Solución
mi solución fue quitarle el height de 100% que tenia la etiqueta a y agregarle un display flex y un justify-center al article que lo contiene.

https://github.com/midudev/javascript-100-proyectos/assets/57204144/bdbb603c-230e-4fd1-ac1f-40bea4fcd039

