### PR TITLE
Add paddle controls with A and D keys

### DIFF
--- a/02-arkanoid-game/index.html
+++ b/02-arkanoid-game/index.html
@@ -213,18 +213,18 @@
 
     function keyDownHandler(event) {
       const { key } = event
-      if (key === 'Right' || key === 'ArrowRight') {
+      if (key === 'Right' || key === 'ArrowRight' || key === 'd') {
         rightPressed = true
-      } else if (key === 'Left' || key === 'ArrowLeft') {
+      } else if (key === 'Left' || key === 'ArrowLeft' || key === 'a') {
         leftPressed = true
       }
     }
 
     function keyUpHandler(event) {
       const { key } = event
-      if (key === 'Right' || key === 'ArrowRight') {
+      if (key === 'Right' || key === 'ArrowRight' || key === 'd') {
         rightPressed = false
-      } else if (key === 'Left' || key === 'ArrowLeft') {
+      } else if (key === 'Left' || key === 'ArrowLeft' || key === 'a') {
         leftPressed = false
       }
     }

--- a/02-arkanoid-game/index.html
+++ b/02-arkanoid-game/index.html
@@ -213,18 +213,18 @@
 
     function keyDownHandler(event) {
       const { key } = event
-      if (key === 'Right' || key === 'ArrowRight' || key === 'd') {
+      if (key === 'Right' || key === 'ArrowRight' || key.toLowerCase() === 'd') {
         rightPressed = true
-      } else if (key === 'Left' || key === 'ArrowLeft' || key === 'a') {
+      } else if (key === 'Left' || key === 'ArrowLeft' || key.toLowerCase() === 'a') {
         leftPressed = true
       }
     }
 
     function keyUpHandler(event) {
       const { key } = event
-      if (key === 'Right' || key === 'ArrowRight' || key === 'd') {
+      if (key === 'Right' || key === 'ArrowRight' || key.toLowerCase() === 'd') {
         rightPressed = false
-      } else if (key === 'Left' || key === 'ArrowLeft' || key === 'a') {
+      } else if (key === 'Left' || key === 'ArrowLeft' || key.toLowerCase() === 'a') {
         leftPressed = false
       }
     }


### PR DESCRIPTION
### **Proposed Changes:**
Added paddle controls to allow movement using the "A" and "D" keys.

### **Details:**
This Pull Request implements functionality to control the game paddle using the "A" and "D" keys. Previously, the paddle could only be controlled using the left and right arrow keys. This addition expands the accessibility of the game by allowing players to use an alternative key combination to control the paddle's movement.

### **Steps to Test:**

1. Clone the repository.
2. Switch to the branch where the new functionality has been added.
3. Run the game and test paddle movement using the "A" and "D" keys.
4. Verify that the paddle responds correctly to the controls and moves left and right according to the keys pressed.