### PR TITLE
Resuelvo codigo inecesario en monkey type clone

### DIFF
--- a/03-midu-typing-game/index.html
+++ b/03-midu-typing-game/index.html
@@ -284,7 +284,7 @@
         $letterToGo.classList.add('active')
 
         $input.value = [
-          ...$prevWord.querySelectorAll('letter.correct, letter.incorrect')
+          ...$prevWord.querySelectorAll('letter.correct')
         ].map($el => $el.innerText)
           .join('')
       }

--- a/03-midu-typing-game/index.html
+++ b/03-midu-typing-game/index.html
@@ -285,9 +285,7 @@
 
         $input.value = [
           ...$prevWord.querySelectorAll('letter.correct, letter.incorrect')
-        ].map($el => {
-          return $el.classList.contains('correct') ? $el.innerText : '*'
-        })
+        ].map($el => $el.innerText)
           .join('')
       }
     }


### PR DESCRIPTION
Al regresar hacia la palabra de atras para resolver los errores, no es necesario traer las palabras incorrectas, con solo traer las palabras correctas, es suficiente para hacerle saber al input cual fue la ultima palabra incorrecta y hacerle llegar a esa, ademas, ahora si pones una palabra correcta, luego una incorrecta, y luego una correcta, lo que hace es posicionarse sobre la palabra correcta al regresar, y desde mi punto de vista queda mejor con el cambio que hice. Saludos midu! 👋