### PR TITLE
Fix Cloudflare rate limit issue

### DIFF
--- a/02-arkanoid-game/index.html
+++ b/02-arkanoid-game/index.html
@@ -186,6 +186,7 @@
     } else if ( // la pelota toca el suelo
       y + dy > canvas.height - ballRadius || y + dy > paddleY + paddleHeight
     ) {
+      gameOver = true
       console.log('Game Over')
       document.location.reload()
     }
@@ -239,7 +240,11 @@
   let frames = 0
   let framesPerSec = fps;
 
+  let gameOver = false;
+
   function draw() {
+    if (gameOver) return
+    
     window.requestAnimationFrame(draw)
 
     const msNow = window.performance.now()


### PR DESCRIPTION
# Fix Cloudflare rate limit issue

## Description
Arkanoid was triggering multiple `location.reload()` calls on game over, which caused a Cloudflare rate limit.
Added a `gameOver` boolean to prevent frames from being drawn once the game is over.

## Steps to Reproduce the Bug
1. Open the [Arkanoid Game](https://www.javascript100.dev/02-arkanoid-game).
  (If you are just opening the `index.html` file locally, you might need to add a timeout to the `location.reload()` to mimic the effect of a slower server)
2. Open the developer tools console.
3. Hold the left or right arrow key when the game starts.
4. Once you lose the game, multiple "Game Over" messages are logged into the console (the amount may vary depending on internet or computer speed).
5. If enough reloads were sent, you'll encounter a Cloudflare Error 1015 "You are being rate limited."
![Cloudflare Error Screenshot](https://github.com/midudev/javascript-100-proyectos/assets/63514002/7e0c6007-efcb-41cd-a22c-41a245dc657e)