### PR TITLE
Fix(tier-maker): duplicate items

### DIFF
--- a/07-tier-maker/index.html
+++ b/07-tier-maker/index.html
@@ -222,6 +222,7 @@
 
     function handleDropFromDesktop(event) {
       event.preventDefault()
+      if (sourceContainer) return
       const { currentTarget, dataTransfer } = event
 
       if (dataTransfer.types.includes('Files')) {


### PR DESCRIPTION
Arregla un pequeño bug al tomar y soltar un item en el elemento "#selector-items" que hace que aparezca un item duplicado debido a que se detecta como un item traido del exterior.

Antes: 

https://github.com/user-attachments/assets/3a4b3543-dbd1-4c32-9dce-2358d89a839d

Despues:

https://github.com/user-attachments/assets/cc65ba11-e07d-4f02-86d7-ba71ae98dd52



