### PR TITLE
Tier-maker: duplicate items and correct CSS when you dropLeave

### DIFF
--- a/07-tier-maker/index.html
+++ b/07-tier-maker/index.html
@@ -174,6 +174,7 @@
     }
 
     function useFilesToCreateItems(files) {
+      if (draggedElement) return
       if (files && files.length > 0) {
         Array.from(files).forEach(file => {
           const reader = new FileReader()
@@ -217,7 +218,7 @@
 
       if (dataTransfer.types.includes('Files')) {
         currentTarget.classList.add('drag-files')
-      }
+      } 
     }
 
     function handleDropFromDesktop(event) {
@@ -228,7 +229,7 @@
         currentTarget.classList.remove('drag-files')
         const { files } = dataTransfer
         useFilesToCreateItems(files)
-      }
+      } 
     }
 
     function handleDrop(event) {
@@ -272,6 +273,7 @@
 
       const { currentTarget } = event
       currentTarget.classList.remove('drag-over')
+      currentTarget.classList.remove('drag-files');
       currentTarget.querySelector('.drag-preview')?.remove()
     }
 


### PR DESCRIPTION
Correción de la duplicación del elemento/foto en "#selector-items", también evitando todo el proceso de la fn createItems (optimizando codigo). También he modificado del mismo box, el css que conservaba la clase al hacer dropLeave. Ahora, retorna a su origen .

Duplicado de la imagen:
![image](https://github.com/user-attachments/assets/0364380c-4a2b-4809-830b-b8b18b39a64b)

Corrección CSS y duplicado al volver a arrastrar a #selector-items:
