### PR TITLE
Constntes recalculadas para cada celda.

### DIFF
--- a/08-excel-js/index.html
+++ b/08-excel-js/index.html
@@ -111,7 +111,7 @@
 
       newState[x][y] = cell
 
-      computeAllCells(newState, generateCellsConstants(newState))
+      computeAllCells(newState)
 
       STATE = newState
 
@@ -128,10 +128,11 @@
       }).join('\n')
     }
 
-    function computeAllCells(cells, constants) {
+    function computeAllCells(cells) {
       console.log('computeAllCells')
       cells.forEach((rows, x) => {
         rows.forEach((cell, y) => {
+          const constants = generateCellsConstants(cells)
           const computedValue = computeValue(cell.value, constants)
           cell.computedValue = computedValue
         })


### PR DESCRIPTION
### Problema
Cuando el valor de una celd depende del valor de vrias celdas, este no se calcula correctamente.
### Ejemplo
![image](https://github.com/user-attachments/assets/6724a34c-153b-4b4c-a1f0-bec1751b3a64)
![image](https://github.com/user-attachments/assets/6234b9c6-c922-4c63-b11d-a9ada68339fb)
![image](https://github.com/user-attachments/assets/d9b74757-76d8-4fe5-9e05-de04baf8b1d4)

Si partimos de este estado y modificmos el valor de la celd A1, solo se modificará el valor de las celds que dependan de A1, como es el cso de A2, pero no el de las que dependan de A2 o de otrs celdas. 

![image](https://github.com/user-attachments/assets/2b0bc5e8-4375-492c-bc0e-7c819effecef)

Dndo así lugar  la imagen en la que 2+2 da 3 (A1+A2) o 2+2+3 da 5 (A1+A2+A3).

Este cambio se soluciona progresivamente a medida que se vuele  renderizar. Si modifico un vlor culquiera para forzar el renderizado os valores se corrigen parcialmente:

![image](https://github.com/user-attachments/assets/8852b319-398b-4b33-b948-dccf43a2fe6c)

Pero es necesario relizar otro cambio para que los cálculos esten completamente correctos en este caso.

![image](https://github.com/user-attachments/assets/452cf4ca-cc4d-4209-84db-74e3823187f6)

Tras la modificción todos estas actualizaciones posteriores se realizan automáticamente.


