### PR TITLE
Drag & Drop from/to the 'selector-items' section duplicates images.

### DIFF
--- a/07-tier-maker/index.html
+++ b/07-tier-maker/index.html
@@ -240,6 +240,7 @@
         sourceContainer.removeChild(draggedElement)
       }
 
+      if (sourceContainer === currentTarget && sourceContainer.id === 'selector-items') return
       if (draggedElement) {
         const src = dataTransfer.getData('text/plain')
         const imgElement = createItem(src)


### PR DESCRIPTION
If you drag and image from the 'selector-items' section and drop it in the same 'selector-items' section, the image gets duplicated.