### PR TITLE
fix(tinder-swipe) Corrige defecto visualizacion edad en Firefox

### DIFF
--- a/01-tinder-swipe/index.html
+++ b/01-tinder-swipe/index.html
@@ -229,7 +229,7 @@
         position: absolute;
         inset: 0;
         display: flex;
-        align-items: flex-end;
+        align-items: last baseline;
         height: 100%;
         width: 100%;
         padding: 16px;
@@ -242,7 +242,6 @@
       & span {
         margin-left: 6px;
         font-size: 18px;
-        line-height: 1.4;
         font-weight: 400;
       }
     }


### PR DESCRIPTION
Actualmente en los navegadores basados en Firefox, la edad no aparece alineada al nombre

Antes:
![before-Firefox](https://github.com/user-attachments/assets/1158bf40-5364-474c-96b5-05158b7cb0a7)

Después:
![after-Firefox](https://github.com/user-attachments/assets/750ffd9e-f994-430c-801a-29b0f0df0879)

